### PR TITLE
anyio/Trio compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Our design goals were roughly:
 
 * Utilize type hints extensively as both a documentation and design by contract
     tool to provide an expressive, readable API.
-* Embrace asyncio as a first class citizen.
+* Embrace anyio/asyncio/trio as a first class citizen.
 * Implement state machines as plain old Python objects with an easily understood
     method and input/output external API surface. Callers shouldn't need to know
     or care about FSM minutiae.

--- a/poetry.lock
+++ b/poetry.lock
@@ -689,17 +689,6 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
-[[package]]
-name = "pytest-asyncio"
-version = "0.20.3"
-description = "Pytest support for asyncio"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pytest-asyncio-0.20.3.tar.gz", hash = "sha256:83cbf01169ce3e8eb71c6c278ccb0574d1a7a3bb8eaaf5e50e0ad342afb33b36"},
-    {file = "pytest_asyncio-0.20.3-py3-none-any.whl", hash = "sha256:f129998b209d04fcc65c96fc85c11e5316738358909a8399e93be553d7656442"},
-]
-
 [package.dependencies]
 pytest = ">=6.1.0"
 
@@ -740,7 +729,7 @@ files = [
 pytest = ">=5.0"
 
 [package.extras]
-dev = ["pre-commit", "pytest-asyncio", "tox"]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "pyyaml"

--- a/poetry.lock
+++ b/poetry.lock
@@ -689,6 +689,17 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
+[[package]]
+name = "pytest-asyncio"
+version = "0.20.3"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-asyncio-0.20.3.tar.gz", hash = "sha256:83cbf01169ce3e8eb71c6c278ccb0574d1a7a3bb8eaaf5e50e0ad342afb33b36"},
+    {file = "pytest_asyncio-0.20.3-py3-none-any.whl", hash = "sha256:f129998b209d04fcc65c96fc85c11e5316738358909a8399e93be553d7656442"},
+]
+
 [package.dependencies]
 pytest = ">=6.1.0"
 
@@ -729,7 +740,7 @@ files = [
 pytest = ">=5.0"
 
 [package.extras]
-dev = ["pre-commit", "tox"]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "pyyaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pydantic = "^1.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"
-pytest-asyncio = "^0.20.0"
+anyio = "^4.1.0"
 devtools = "^0.6.1"
 pytest-mock = "^3.10.0"
 isort = "^5.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ add-trailing-comma = "^2.1.0"
 pyformat = "^0.7"
 pylint = "^2.6.0"
 flake8-quotes = "^3.2.0"
+trio = "^0.23.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/statesman.py
+++ b/statesman.py
@@ -170,7 +170,7 @@ class BaseModel(pydantic.BaseModel):
             for action in self._get_actions(type_):
                 result = await action(*args, **kwargs)
                 results.append(result)
-                if result == False:
+                if result is False:
                     break
 
             return results

--- a/statesman.py
+++ b/statesman.py
@@ -119,10 +119,10 @@ class Action(pydantic.BaseModel):
         """Call the action with the matching parameters and return the
         result."""
         matched_args, matched_kwargs = _parameters_matching_signature(self.signature, *args, **kwargs)
-        if asyncio.iscoroutinefunction(self.callable):
-            return await self.callable(*matched_args, **matched_kwargs)
-        else:
-            return self.callable(*matched_args, **matched_kwargs)
+        result = self.callable(*matched_args, **matched_kwargs)
+        if inspect.iscoroutine(result):
+            result = await result
+        return result
 
     class Config:
         arbitrary_types_allowed = True
@@ -1359,10 +1359,10 @@ async def _call_with_matching_parameters(callable: Callable, *args, **kwargs) ->
     matched_args, matched_kwargs = _parameters_matching_signature(
         inspect.Signature.from_callable(callable), *args, **kwargs
     )
-    if asyncio.iscoroutinefunction(callable):
-        return await callable(*matched_args, **matched_kwargs)
-    else:
-        return callable(*matched_args, **matched_kwargs)
+    result = callable(*matched_args, **matched_kwargs)
+    if inspect.iscoroutine(result):
+        result = await result
+    return result
 
 
 class HistoryMixin(pydantic.BaseModel):

--- a/statesman_test.py
+++ b/statesman_test.py
@@ -1,4 +1,4 @@
-import asyncio
+import anyio
 import builtins
 import contextlib
 import datetime
@@ -137,11 +137,11 @@ class TestAction:
         action = statesman.Action(callable=lambda: 1234, type=statesman.Action.Types.entry)
         assert action.type == 'entry'
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_call_action(self) -> None:
         action = statesman.Action(callable=lambda: 1234)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_argument_matching(self) -> None:
         # TODO: Test with and without *args and **kwargs
         def action_body(count: int, another: bool = False, *args, something=None, number=1234) -> None:
@@ -166,19 +166,19 @@ class TestStateMachine:
     def state_machine(self) -> statesman.StateMachine:
         return statesman.StateMachine(states=statesman.State.from_enum(States))
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_states_names(self, state_machine: statesman.StateMachine) -> None:
         states = state_machine.get_states('starting', 'stopped')
         assert len(states) == 2
         assert list(map(lambda i: i.name, states)) == ['starting', 'stopped']
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_states_by_state_enum(self, state_machine: statesman.StateMachine) -> None:
         states = state_machine.get_states(States)
         assert len(states) == 4
         assert list(map(lambda i: i.name, states)) == ['starting', 'running', 'stopping', 'stopped']
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_states_by_state_enum_list(self, state_machine: statesman.StateMachine) -> None:
         states = state_machine.get_states(States.starting, States.running)
         assert len(states) == 2
@@ -198,7 +198,7 @@ class TestTransition:
 
         return statesman.Transition(state_machine=state_machine, source=starting, target=stopping)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_lifecycle(self, transition: statesman.Transition) -> None:
         assert transition.created_at
         assert transition.started_at is None
@@ -209,20 +209,20 @@ class TestTransition:
         assert transition.finished_at is not None
         assert transition.cancelled == False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_runtime(self, transition: statesman.Transition) -> None:
         assert transition.runtime is None
         await transition()
         assert transition.runtime is not None
         assert isinstance(transition.runtime, datetime.timedelta)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_finished(self, transition: statesman.Transition) -> None:
         assert transition.is_finished is False
         await transition()
         assert transition.is_finished is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_executing(self, transition: statesman.Transition) -> None:
         was_executing = None
 
@@ -236,7 +236,7 @@ class TestTransition:
         assert was_executing is True
         assert transition.is_executing is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_args_and_kwargs(self, transition: statesman.Transition) -> None:
         assert transition.args is None
         assert transition.kwargs is None
@@ -244,7 +244,7 @@ class TestTransition:
         assert transition.args == (1234,)
         assert transition.kwargs == {'foo': 'Bar'}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_params_passed_to_actions(self, transition: statesman.Transition) -> None:
         called = False
 
@@ -259,7 +259,7 @@ class TestTransition:
         await transition(1234, foo='Bar')
         assert called is True  # Ensure that our inner assertions actually ran
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_internal_transition(self, mocker) -> None:
         state_machine = statesman.StateMachine()
         state_machine.add_states(statesman.State.from_enum(States))
@@ -288,7 +288,7 @@ class TestTransition:
         entry_stub.assert_not_called()
         exit_stub.assert_not_called()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_self_transition(self, mocker) -> None:
         state_machine = statesman.StateMachine()
         state_machine.add_states(statesman.State.from_enum(States))
@@ -317,14 +317,14 @@ class TestTransition:
         entry_stub.assert_called_once()
         exit_stub.assert_called_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_results_is_none_when_event_is_none(self, transition: statesman.Transition) -> None:
         assert transition.event is None
         assert transition.results is None
         assert await transition()
         assert transition.results is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_results_is_populated_with_return_value_of_on_event_handlers(self, mocker) -> None:
         state_machine = statesman.StateMachine()
         state_machine.add_states(statesman.State.from_enum(States))
@@ -416,14 +416,14 @@ class TestProgrammaticStateMachine:
         state = state_machine.states[0]
         assert state == States.starting
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enter_state_name_not_found(self) -> None:
         state_machine = statesman.StateMachine(states=statesman.State.from_enum(States))
         assert state_machine.state is None
         with pytest.raises(LookupError, match='state entry failed: no state was found with the name "invalid"'):
             await state_machine.enter_state('invalid')
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enter_state_enum_not_found(self) -> None:
         class OtherStates(statesman.StateEnum):
             invalid = 'invalid'
@@ -433,7 +433,7 @@ class TestProgrammaticStateMachine:
         with pytest.raises(LookupError, match='state entry failed: no state was found with the name "invalid"'):
             await state_machine.enter_state(OtherStates.invalid)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enter_state_not_in_machine(self) -> None:
         state = statesman.State('invalid')
         state_machine = statesman.StateMachine(states=statesman.State.from_enum(States))
@@ -441,7 +441,7 @@ class TestProgrammaticStateMachine:
         with pytest.raises(ValueError, match='state entry failed: the state object given is not in the state machine'):
             await state_machine.enter_state(state)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enter_state_runs_state_actions(self, mocker) -> None:
         state_machine = statesman.StateMachine()
         state_machine.add_states(statesman.State.from_enum(States))
@@ -464,12 +464,12 @@ class TestProgrammaticStateMachine:
         stub.assert_called()
         assert stub.call_count == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_create_no_state(self) -> None:
         state_machine = await statesman.StateMachine.create(states=statesman.State.from_enum(States))
         assert state_machine.state is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_create_enter_specific_state(self) -> None:
         state_machine = await statesman.StateMachine.create(
             states=statesman.State.from_enum(States),
@@ -477,7 +477,7 @@ class TestProgrammaticStateMachine:
         )
         assert state_machine.state == States.stopping
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     @pytest.mark.parametrize(
         ('callback'),
         [
@@ -487,7 +487,7 @@ class TestProgrammaticStateMachine:
             'after_transition',
         ],
     )
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enter_state_with_args(self, callback, mocker) -> None:
         state_machine = statesman.StateMachine(states=statesman.State.from_enum(States), state=States.starting)
         assert state_machine.state == States.starting
@@ -501,7 +501,7 @@ class TestProgrammaticStateMachine:
             assert callback_mock.call_args.args[1]
             assert callback_mock.call_args.kwargs == {'foo': 'bar'}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_doesnt_run_state_actions_for_internal_transitions(self, mocker) -> None:
         state_machine = statesman.StateMachine(states=statesman.State.from_enum(States), state=States.starting)
         assert state_machine.state == States.starting
@@ -522,7 +522,7 @@ class TestProgrammaticStateMachine:
             entry_action.assert_not_called()
             exit_action.assert_not_called()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_runs_state_actions_for_self_transitions(self, mocker) -> None:
         state_machine = statesman.StateMachine(states=statesman.State.from_enum(States), state=States.starting)
         assert state_machine.state == States.starting
@@ -557,7 +557,7 @@ class TestProgrammaticStateMachine:
                                  'source and target states must be the same for internal or self transitions'),
                               ],
                              )
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_raises_if_states_and_transition_type_are_inconsistent(
         self, target_state: statesman.StateEnum, transition_type: statesman.Transition.Types, error_message: str
     ) -> None:
@@ -568,7 +568,7 @@ class TestProgrammaticStateMachine:
             await state_machine.enter_state(target_state, type_=transition_type)
 
     class TestEntryConfig:
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_allow(self) -> None:
             state_machine = statesman.StateMachine(states=statesman.State.from_enum(States))
             state_machine._config.state_entry = statesman.Entry.allow
@@ -580,7 +580,7 @@ class TestProgrammaticStateMachine:
             assert await state_machine.enter_state(States.stopped)
             assert state_machine.state == States.stopped
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_initial(self) -> None:
             # Enter once for initial, then raise on next try
             state_machine = statesman.StateMachine(states=statesman.State.from_enum(States))
@@ -592,7 +592,7 @@ class TestProgrammaticStateMachine:
             with pytest.raises(RuntimeError, match="state entry failed: `enter_state` is only available to set initial state"):
                 assert await state_machine.enter_state(States.stopping)
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_ignore(self) -> None:
             # Return false every time
             state_machine = statesman.StateMachine(states=statesman.State.from_enum(States))
@@ -605,7 +605,7 @@ class TestProgrammaticStateMachine:
             assert not await state_machine.enter_state(States.stopped)
             assert state_machine.state is None
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_forbid(self) -> None:
             state_machine = statesman.StateMachine(states=statesman.State.from_enum(States))
             state_machine._config.state_entry = statesman.Entry.forbid
@@ -701,17 +701,17 @@ class TestProgrammaticStateMachine:
             )
             return state_machine
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_get_event(self, state_machine: statesman.StateMachine) -> None:
             event = state_machine.get_event('finish')
             assert event is not None
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_get_event_not_found(self, state_machine: statesman.StateMachine) -> None:
             event = state_machine.get_event('invalid')
             assert event is None
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_get_event_invalid_type_raises(self, state_machine: statesman.StateMachine) -> None:
             assert state_machine.state is None
             with pytest.raises(TypeError) as e:
@@ -719,7 +719,7 @@ class TestProgrammaticStateMachine:
 
             assert str(e.value) == "cannot get event for name of type \"int\": 1234"
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_can_trigger(self, state_machine: statesman.StateMachine) -> None:
             await state_machine.enter_state(States.starting)
             assert state_machine.state == States.starting
@@ -730,7 +730,7 @@ class TestProgrammaticStateMachine:
             assert not state_machine.can_trigger_event('finish')
             assert state_machine.can_trigger_event('reset')
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_can_trigger_from_state(self, state_machine: statesman.StateMachine) -> None:
             assert state_machine.can_trigger_event('finish', from_state=States.starting)
             assert state_machine.can_trigger_event('finish', from_state="starting")
@@ -740,21 +740,21 @@ class TestProgrammaticStateMachine:
             assert not state_machine.can_trigger_event('reset', from_state="starting")
             assert not state_machine.can_trigger_event('reset', from_state=state_machine.get_state("starting"))
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_can_trigger_from_state(self, state_machine: statesman.StateMachine) -> None:
             assert state_machine.triggerable_events() == []
             assert state_machine.triggerable_events(from_state=None) == []
             assert state_machine.triggerable_events(from_state="stopping") == [state_machine.get_event("reset")]
             assert state_machine.triggerable_events(from_state="starting") == [state_machine.get_event("finish")]
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_by_name(self, state_machine: statesman.StateMachine) -> None:
             await state_machine.enter_state(States.starting)
             assert state_machine.state == States.starting
             await state_machine.trigger_event('finish')
             assert state_machine.state == States.stopping
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_by_event(self, state_machine: statesman.StateMachine) -> None:
             await state_machine.enter_state(States.starting)
             assert state_machine.state == States.starting
@@ -762,25 +762,25 @@ class TestProgrammaticStateMachine:
             await state_machine.trigger_event(event)
             assert state_machine.state == States.stopping
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_trigger_without_state_raises(self, state_machine: statesman.StateMachine) -> None:
             assert state_machine.state is None
             with pytest.raises(RuntimeError, match='event trigger failed: the "finish" event does not support initial state transitions'):
                 await state_machine.trigger_event('finish')
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_trigger_from_incompatible_state(self, state_machine: statesman.StateMachine) -> None:
             await state_machine.enter_state(States.stopping)
             with pytest.raises(RuntimeError, match='event trigger failed: the "finish" event cannot be triggered from the current state of "stopping"'):
                 await state_machine.trigger_event('finish')
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_with_invalid_name(self, state_machine: statesman.StateMachine) -> None:
             await state_machine.enter_state(States.starting)
             with pytest.raises(LookupError, match="event trigger failed: no event was found with the name \"invalid\""):
                 await state_machine.trigger_event('invalid')
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_with_invalid_type(self, state_machine: statesman.StateMachine) -> None:
             await state_machine.enter_state(States.starting)
             with pytest.raises(TypeError, match="event trigger failed: cannot trigger an event of type \"int\": 1234"):
@@ -803,7 +803,7 @@ class TestProgrammaticStateMachine:
                     (list, [31337, 187, 420]),
                 ]
             )
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_return_types(self, state_machine: statesman.StateMachine, event, return_type, expected_return_value) -> None:
                 await state_machine.enter_state(States.starting)
                 assert state_machine.state == States.starting
@@ -819,7 +819,7 @@ class TestProgrammaticStateMachine:
                     (list, [31337, 187, 420]),
                 ]
             )
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_return_types_override_on_trigger(self, state_machine: statesman.StateMachine, event, return_type, expected_return_value) -> None:
                 await state_machine.enter_state(States.starting)
                 assert state_machine.state == States.starting
@@ -827,7 +827,7 @@ class TestProgrammaticStateMachine:
                 result = await state_machine.trigger_event('finish', return_type=return_type)
                 assert result == expected_return_value
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_transition_return_type(self, state_machine: statesman.StateMachine, event) -> None:
                 await state_machine.enter_state(States.starting)
                 assert state_machine.state == States.starting
@@ -838,7 +838,7 @@ class TestProgrammaticStateMachine:
                 assert transition.succeeded == True
                 assert transition.results == [31337, 187, 420]
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_with_event_not_in_machine(self, state_machine: statesman.StateMachine) -> None:
             invalid_event = statesman.Event(
                 name='invalid',
@@ -849,7 +849,7 @@ class TestProgrammaticStateMachine:
             with pytest.raises(TypeError, match="event trigger failed: cannot trigger an event of type \"int\": 1234"):
                 await state_machine.trigger_event(1234)
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_cancel_via_guard_state_machine_method(self, state_machine: statesman.StateMachine, mocker) -> None:
             await state_machine.enter_state(States.starting)
             with extra(state_machine):
@@ -859,7 +859,7 @@ class TestProgrammaticStateMachine:
                 guard_mock.assert_awaited_once()
                 assert not success, 'should have been guarded'
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_returning_none_from_guard_does_not_cancel(self, state_machine: statesman.StateMachine, mocker) -> None:
             await state_machine.enter_state(States.starting)
             with extra(state_machine):
@@ -869,7 +869,7 @@ class TestProgrammaticStateMachine:
                 guard_mock.assert_awaited_once()
                 assert success, 'should not have been guarded'
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_returning_invalid_value_from_guard_raises_value_error(self, state_machine: statesman.StateMachine, mocker) -> None:
             await state_machine.enter_state(States.starting)
             with extra(state_machine):
@@ -879,7 +879,7 @@ class TestProgrammaticStateMachine:
                     await state_machine.trigger_event('finish')
                 guard_mock.assert_awaited_once()
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_non_assertion_errors_raise(self, state_machine: statesman.StateMachine, mocker) -> None:
             await state_machine.enter_state(States.starting)
             with extra(state_machine):
@@ -891,7 +891,7 @@ class TestProgrammaticStateMachine:
                     guard_mock.assert_awaited_once()
                     assert not success, 'should have been guarded'
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_guard_with_silence(self, state_machine: statesman.StateMachine, mocker) -> None:
             state_machine._config.guard_with = statesman.Guard.silence
             await state_machine.enter_state(States.starting)
@@ -902,7 +902,7 @@ class TestProgrammaticStateMachine:
                 guard_mock.assert_awaited_once()
                 assert not success, 'should have been guarded'
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_guard_with_warning(self, state_machine: statesman.StateMachine, mocker) -> None:
             state_machine._config.guard_with = statesman.Guard.warning
             await state_machine.enter_state(States.starting)
@@ -912,7 +912,7 @@ class TestProgrammaticStateMachine:
                 with pytest.warns(UserWarning, match='transition guard failure: guard_transition returned False'):
                     await state_machine.trigger_event('finish')
 
-        @pytest.mark.asyncio
+        @pytest.mark.anyio
         async def test_guard_with_exception(self, state_machine: statesman.StateMachine, mocker) -> None:
             state_machine._config.guard_with = statesman.Guard.exception
             await state_machine.enter_state(States.starting)
@@ -923,7 +923,7 @@ class TestProgrammaticStateMachine:
                     await state_machine.trigger_event('finish')
 
         class TestActions:
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_guard(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -933,7 +933,7 @@ class TestProgrammaticStateMachine:
                 assert await state_machine.trigger_event('finish'), 'guard passed'
                 guard_action.assert_called_once()
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_cancel_via_guard_action_bool(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -946,7 +946,7 @@ class TestProgrammaticStateMachine:
                 guard_action.assert_called_once()
                 assert not success, 'should have been cancelled by guard'
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_none_return_value_from_guard_does_not_cancel(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -958,7 +958,7 @@ class TestProgrammaticStateMachine:
                 guard_action.assert_called_once()
                 assert success, 'should not have been cancelled by guard'
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_invalid_return_value_from_guard_raises_value_error(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -970,7 +970,7 @@ class TestProgrammaticStateMachine:
                     await state_machine.trigger_event('finish')
                 guard_action.assert_called_once()
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_cancel_via_guard_action_exception(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -983,7 +983,7 @@ class TestProgrammaticStateMachine:
                 assert not success, 'cancelled by guard'
                 guard_action.assert_called_once()
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_guard_actions_run_sequentially(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -997,7 +997,7 @@ class TestProgrammaticStateMachine:
                 guard_action1.assert_called_once()
                 guard_action2.assert_not_called()
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_guard_with_silence(self, state_machine: statesman.StateMachine, mocker) -> None:
                 state_machine._config.guard_with = statesman.Guard.silence
                 await state_machine.enter_state(States.starting)
@@ -1008,7 +1008,7 @@ class TestProgrammaticStateMachine:
                 event.add_action(lambda: guard_action(), statesman.Action.Types.guard)
                 success = await state_machine.trigger_event('finish')
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_guard_with_warning(self, state_machine: statesman.StateMachine, mocker) -> None:
                 state_machine._config.guard_with = statesman.Guard.warning
                 await state_machine.enter_state(States.starting)
@@ -1020,7 +1020,7 @@ class TestProgrammaticStateMachine:
                 with pytest.warns(UserWarning, match='transition guard failure: guard action returned False'):
                     await state_machine.trigger_event('finish')
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_guard_with_exception(self, state_machine: statesman.StateMachine, mocker) -> None:
                 state_machine._config.guard_with = statesman.Guard.exception
                 await state_machine.enter_state(States.starting)
@@ -1032,7 +1032,7 @@ class TestProgrammaticStateMachine:
                 with pytest.raises(RuntimeError, match="transition guard failure: guard action returned False"):
                     await state_machine.trigger_event('finish')
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_before(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -1041,7 +1041,7 @@ class TestProgrammaticStateMachine:
                 await state_machine.trigger_event('finish')
                 before_action.assert_called_once()
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_after(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -1050,7 +1050,7 @@ class TestProgrammaticStateMachine:
                 await state_machine.trigger_event('finish')
                 after_action.assert_called_once()
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_on(self, state_machine: statesman.StateMachine, mocker) -> None:
                 await state_machine.enter_state(States.starting)
                 event = state_machine.get_event('finish')
@@ -1059,7 +1059,7 @@ class TestProgrammaticStateMachine:
                 await state_machine.trigger_event('finish')
                 on_action.assert_called_once()
 
-            @pytest.mark.asyncio
+            @pytest.mark.anyio
             async def test_inheritable_actions(self, state_machine: statesman.StateMachine, mocker) -> None:
                 with extra(state_machine):
                     guard_transition = mocker.spy(state_machine, 'guard_transition')
@@ -1196,13 +1196,13 @@ class TestDecoratorStateMachine:
     def state_machine(self) -> statesman.StateMachine:
         return TestDecoratorStateMachine.ProcessLifecycle()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_states_added(self, state_machine: statesman.StateMachine) -> None:
         assert len(state_machine.states) == 4
         assert state_machine.states[0].name == 'starting'
         assert state_machine.states[0].description == 'Starting...'
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_events_added(self, state_machine: statesman.StateMachine) -> None:
         event = state_machine.get_event('start')
         assert event
@@ -1210,14 +1210,14 @@ class TestDecoratorStateMachine:
         assert event.sources == [None]
         assert event.target == States.starting
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_event_through_method_call(self, state_machine: statesman.StateMachine) -> None:
         assert state_machine.state is None
         await state_machine.start()
         assert state_machine.state
         assert state_machine.state == States.starting
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_event_through_method_call_with_args(self, state_machine: statesman.StateMachine, mocker) -> None:
         with extra(state_machine):
             callback_mock = mocker.spy(state_machine, 'on_transition')
@@ -1226,7 +1226,7 @@ class TestDecoratorStateMachine:
             assert 31337 in callback_mock.call_args.args
             assert {'this': 'That'} == callback_mock.call_args.kwargs
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_self_transition(self, state_machine: statesman.StateMachine, mocker) -> None:
         await state_machine.enter_state(States.stopped)
 
@@ -1248,7 +1248,7 @@ class TestDecoratorStateMachine:
             entry_stub.assert_called_once()
             exit_stub.assert_called_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_process_lifecycle(self, state_machine: statesman.StateMachine, mocker) -> None:
         assert state_machine.pid is None
         assert state_machine.command is None
@@ -1274,12 +1274,12 @@ class TestDecoratorStateMachine:
         ]
 
         # Let the runloop cycle
-        await asyncio.sleep(0.001)
+        await anyio.sleep(0.001)
         assert state_machine.state == States.stopped
         assert state_machine.pid is None
         assert state_machine.command is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enter_states(self, state_machine: statesman.StateMachine) -> None:
         assert state_machine.state is None
         await state_machine.enter_state(States.starting)
@@ -1339,7 +1339,7 @@ def extra(
         obj.__config__.extra = original
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_matching_signature_overlapping_params() -> None:
     def some_function(transition: str, *args, **kwargs) -> None:
         ...
@@ -1378,7 +1378,7 @@ class TestSequencer:
         async def terminate(self, *args, **kwargs) -> None:
             ...
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sequencing(self) -> None:
         state_machine = await TestSequencer.StateMachine.create()
         state_machine.sequence(


### PR DESCRIPTION
This patch (OK, three of them) adds Trio compatibility, by way of anyio.

It also fixes two minor other issues, in separate patches:

* don't use `iscoroutinefunction`. That prevents wrapping async functions with a sync wrapper, which is perfectly legitimate Python code.
* don't compare to `False` with "==". Either use "not", if `None`, zero or the empty string should be considered false, or "is" if they should not be. I opted for the latter approach.
